### PR TITLE
Add scheme and host

### DIFF
--- a/server.go
+++ b/server.go
@@ -412,12 +412,24 @@ func isHostPort(str string) bool {
 	return err == nil
 }
 
-func (rp *requestParam) parseURL() (*url.URL, error) {
+func (rp *requestParam) parseURL() (u *url.URL, err error) {
 	if rp.method == "CONNECT" {
-		return &url.URL{Host: rp.authority}, nil
+		return &url.URL{
+			Host:   rp.authority,
+			Scheme: rp.scheme,
+			Path:   rp.path,
+		}, nil
+
 	}
 	// TODO: handle asterisk '*' requests + test
-	return url.ParseRequestURI(rp.path)
+	u, err = url.ParseRequestURI(rp.path)
+	if u.Scheme == "" {
+		u.Scheme = rp.scheme
+	}
+	if u.Host == "" {
+		u.Host = rp.authority
+	}
+	return
 }
 
 // stream represents a stream. This is the minimal metadata needed by


### PR DESCRIPTION
修复https可能会出现的循环重定向问题
因为 [govps.go#L228)](https://github.com/phuslu/goproxy/blob/master/fetchserver/vps/govps.go#L228) 的原因，所以感觉在这边修复更好一些。